### PR TITLE
Refer to records' factory functions

### DIFF
--- a/src/thrift_clj/gen/types.clj
+++ b/src/thrift_clj/gen/types.clj
@@ -139,6 +139,8 @@
         `(do
            ~@(when (reload-types? thrift-type)
                [`(ns-unmap '~current-ns '~clojure-type)
+                `(ns-unmap '~current-ns '~(symbol (str "->" clojure-type)))
+                `(ns-unmap '~current-ns '~(symbol (str "map->" clojure-type)))
                 `(nsp/internal-ns-remove '~thrift-type)])
            (nsp/internal-ns
              ~thrift-type 
@@ -146,7 +148,11 @@
              ~(extend-thrift-type clojure-type thrift-type mta))
            (nsp/internal-ns-import
              ~thrift-type
-             ~clojure-type)))
+             ~clojure-type)
+           (nsp/internal-ns-refer
+             '~thrift-type
+             '~(symbol (str "->" clojure-type))
+             '~(symbol (str "map->" clojure-type)))))
       (catch Exception ex
         (error ex "when importing type:" thrift-type)
         (throw (Exception.

--- a/src/thrift_clj/utils/namespaces.clj
+++ b/src/thrift_clj/utils/namespaces.clj
@@ -79,6 +79,18 @@
                                   (.getMessage ex)))))))
     (throw (Exception. (str "No internal Namespace for: " ns-key)))))
 
+(defn internal-ns-refer
+  "Refers to the named vars of the given internal Namespace."
+  [ns-key & symbols]
+  (if-let [ns-data (@internal-namespaces ns-key)]
+    (let [ns-id (:ns-name ns-data)]
+      (try
+        (refer ns-id :only symbols)
+        (catch Exception ex
+          (throw (Exception. (str "Failed to require internal Namespace for: " ns-key " (" ns-id ")\n"
+                                  (.getMessage ex)))))))
+    (throw (Exception. (str "No internal Namespace for: " ns-key)))))
+
 (defmacro internal-ns-import
   "Import Classes from the given internal Namespace."
   [ns-key & types]

--- a/test-thrift/clj/thrift_clj/gen/types_test.clj
+++ b/test-thrift/clj/thrift_clj/gen/types_test.clj
@@ -88,3 +88,10 @@
     (vals (:peopleMap cpl)) => #(every? (partial instance? Person) %)
     (keys (:peopleMap rpl)) => #(every? integer? %)
     (vals (:peopleMap rpl)) => #(every? (partial instance? Person) %)))
+
+(fact "about instantiating records with factory functions"
+  (let [positional (->Location 12345 "City" Country/US)
+        map-args (map->Location {:zip 12345 :city "City" :country Country/US})
+        standard (Location. 12345 "City" Country/US)]
+    positional => standard
+    map-args => standard))


### PR DESCRIPTION
This automatically refers to record factory functions like `->MyStruct` and `map->MyStruct`, providing alternate options for instantiation (alongside `MyStruct.`). The map-based function in particular makes it more pleasant to instantiate records for structs with large numbers of arguments.
