### PR TITLE
Move concrete logger to dev dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :repositories  {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
   :exclusions [org.clojure/clojure]
 
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-log4j12 "1.7.5"]]}
+  :profiles {:dev {:dependencies [[ch.qos.logback/logback-classic "1.0.13"]]}
              :test {:dependencies [[midje "1.5.1"]]
                     :plugins [[lein-midje "3.0.1"]
                               [lein-thriftc "0.1.0"]]


### PR DESCRIPTION
Hi Yannick,

I've moved log4j to be a dev-only dependency so clients can use whichever (slf4j-compliant) logging system they please.

FYI since log4j is currently not configured in the project, it still emits the same warnings (that at least I have been getting) from before (e.g. upon `lein midje-all`):

```
log4j:WARN No appenders could be found for logger (ns-456750269).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

I've found that changing the dev dependency to logback, log4j's successor, works as a drop-in replacement without the need for configuration, and the warnings disappear:

`[ch.qos.logback/logback-classic "1.0.13"]`

If you would like, I can add another commit to the pull request to switch this dev dependency over to logback.

Thanks for this project!
Brian
