### PR TITLE
update to libthrift 0.9.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.logging "0.2.6"]
                  [org.reflections/reflections "0.9.9-RC1"]
-                 [org.apache.thrift/libthrift "0.9.0" :exclusions [org.slf4j/slf4j-api]]
+                 [org.apache.thrift/libthrift "0.9.1" :exclusions [org.slf4j/slf4j-api]]
                  [javax.servlet/servlet-api "2.5"]
                  [potemkin "0.3.2"]]
   :repositories  {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}

--- a/src/thrift_clj/protocol/core.clj
+++ b/src/thrift_clj/protocol/core.clj
@@ -32,11 +32,10 @@
 ;; ## Protocol Implementations
 
 (defmethod protocol-factory* :binary
-  [_ {:keys[strict-read strict-write read-length]}]
+  [_ {:keys[strict-read strict-write]}]
   (TBinaryProtocol$Factory. 
     (boolean strict-read)
-    (boolean strict-write)
-    (int (or read-length 0))))
+    (boolean strict-write)))
 
 (defmethod protocol-factory* :compact
   [_ {:keys[max-network-bytes]}]


### PR DESCRIPTION
Only difference seems to be that TBinaryProtocol$Factory's constructor changed to drop the read length option.
