### PR TITLE
Imported client functions should be accessible only via namespace

### DIFF
--- a/test-thrift/clj/thrift_clj/gen/clients_test.clj
+++ b/test-thrift/clj/thrift_clj/gen/clients_test.clj
@@ -15,6 +15,11 @@
   TB/findByName => fn?
   TB/findByLocation => fn?)
 
+(fact "about current namespace after service import"
+  storePerson => nil?
+  findByName => nil?
+  findByLocation => nil?)
+
 (fact "about the client var"
   TB => thriftclj.services.TelephoneBook$Client)
 


### PR DESCRIPTION
Hi,

I just want to clarify if current namespace should adopt functions from imported service. I'd expect them to be accessible via namespace only (`TB` in this case). I don't have much experience with Clojure so perhaps I'm doing something wrong? I've added a failing test case, but unfortunately I don't have enough experience yet to fix it (if it needs fixing at all).

Thanks!
