### PR TITLE
Exclude clojure.core in internal namespaces

### DIFF
--- a/src/thrift_clj/utils/namespaces.clj
+++ b/src/thrift_clj/utils/namespaces.clj
@@ -53,7 +53,7 @@
     (let [current-ns (ns-name *ns*)
           unique-name (symbol (str "ns" (.hashCode (str ns-key))))]
       `(do
-         (ns ~unique-name)
+         (ns ~unique-name (:refer-clojure :only []))
          ~@body
          (in-ns '~current-ns)
          (internal-ns-add '~ns-key '~unique-name)


### PR DESCRIPTION
When generating clients for thrift interfaces where the name of a method clashes with a method from clojure.core, a warning is displayed for overriding the function, and an "attempting to call undefined fn" error is thrown at runtime for AOT compiled code.

This PR helps overcome this issue by excluding all symbols from clojure.core, as they should not be needed in that ns anyways.
