### PR TITLE
Handle fields of type binary

### DIFF
--- a/src/thrift_clj/gen/types.clj
+++ b/src/thrift_clj/gen/types.clj
@@ -35,6 +35,15 @@
 (defbase java.lang.Double)
 (defbase java.lang.Boolean)
 
+(extend-type (class (byte-array 0))
+  c/Value
+  (to-thrift* [this]
+    (java.nio.ByteBuffer/wrap this))
+  (to-thrift-unchecked* [this]
+    (c/to-thrift* this))
+  (to-clj* [this]
+    this))
+
 (extend-type java.util.Set
   c/Value
   (to-thrift* [this]

--- a/src/thrift_clj/thrift/types.clj
+++ b/src/thrift_clj/thrift/types.clj
@@ -58,7 +58,7 @@
 
 (defmethod extend-field-metadata-map :string
   [m _]
-  (assoc m :wrapper `str))
+  (assoc m :wrapper `identity))
 
 (defmethod extend-field-metadata-map :set
   [m _]


### PR DESCRIPTION
This push adds support for fields tagged with "binary" type in thrift IDL. These fields are represented as byte arrays and ByteBuffer in generated code. However, they are tagged as STRING in thrift metadata.

Note: This is a compatibility-breaking change. The non-string values for string fields will no longer be converted to string using ```str```. The client code is responsible for ensuring that string fields are set to string values.