### PR TITLE
Always generate namespace registration code

### DIFF
--- a/src/thrift_clj/utils/namespaces.clj
+++ b/src/thrift_clj/utils/namespaces.clj
@@ -49,16 +49,15 @@
 (defmacro internal-ns
   "Create new internal Namespace."
   [ns-key & body]
-  (when-not (@internal-namespaces ns-key)
-    (let [current-ns (ns-name *ns*)
-          unique-name (symbol (str "ns" (.hashCode (str ns-key))))]
-      `(do
-         (ns ~unique-name
-           (:refer-clojure :only ~'[fn find-ns]))
-         ~@body
-         (in-ns '~current-ns)
-         (internal-ns-add '~ns-key '~unique-name)
-         nil))))
+  (let [current-ns (ns-name *ns*)
+        unique-name (symbol (str "ns" (.hashCode (str ns-key))))]
+    `(do
+       (ns ~unique-name
+         (:refer-clojure :only ~'[fn find-ns]))
+       ~@body
+       (in-ns '~current-ns)
+       (internal-ns-add '~ns-key '~unique-name)
+       nil)))
 
 (defn internal-namespace-exists?
   "Does a given internal Namespace exist?"


### PR DESCRIPTION
`(internal-ns)` should always register the internal namespace. When AOT-compilation is enabled and a thrift type is imported by 2 different namespaces in a project, only one of them will have the namespace initialization code. When the other namespace is dynamically loaded later (and the first namespace is not loaded) the internal namespace doesn't exist and `(internal-namespace-refer)` will fail.